### PR TITLE
feat: add showCurrentTemperatureAsTarget option to config

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -48,6 +48,12 @@
         "condition": {
           "functionBody": "return model.authMode === 'token';"
         }
+      },
+      "showCurrentTemperatureAsTarget": {
+        "title": "Show Current Temperature as Target Temperature",
+        "type": "boolean",
+        "default": true,
+        "description": "When set to `true`, displays the accessory's target temperature on the Apple Home screen, but may inaccurately reflect the home's climate as the target temperature. When `false`, shows \"--°\" with a \"No response\" warning on the Apple Home screen, but does not set the home's climate to the target temperature."
       }
     }
   }

--- a/src/homebridge/electric-mat.device.ts
+++ b/src/homebridge/electric-mat.device.ts
@@ -151,6 +151,6 @@ export default class ElectricMat {
     // this device does not support to get current temperature
     // so, throw an error to indicate that the operation is not supported
     const { HAPStatus, HapStatusError } = this.platform.api.hap;
-    throw new HapStatusError(HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+    throw new HapStatusError(HAPStatus.NOT_ALLOWED_IN_CURRENT_STATE);
   }
 }

--- a/src/homebridge/electric-mat.device.ts
+++ b/src/homebridge/electric-mat.device.ts
@@ -50,6 +50,7 @@ export default class ElectricMat {
         Name,
         CurrentHeatingCoolingState,
         TargetHeatingCoolingState,
+        CurrentTemperature,
         TargetTemperature,
         TemperatureDisplayUnits,
       },
@@ -62,9 +63,12 @@ export default class ElectricMat {
       || this.accessory.addService(Thermostat);
 
     // name, temp unit
-    thermostat
-      .setCharacteristic(Name, device.name)
-      .setCharacteristic(TemperatureDisplayUnits, TemperatureDisplayUnits.CELSIUS);
+    thermostat.setCharacteristic(Name, device.name);
+    thermostat.getCharacteristic(TemperatureDisplayUnits)
+      .setProps({
+        validValues: [TemperatureDisplayUnits.CELSIUS],
+      })
+      .setValue(TemperatureDisplayUnits.CELSIUS);
 
     // current state
     thermostat.getCharacteristic(CurrentHeatingCoolingState)
@@ -91,6 +95,10 @@ export default class ElectricMat {
       })
       .onGet(this.getTemperature.bind(this))
       .onSet(this.setTemperature.bind(this));
+
+    // current temperature
+    thermostat.getCharacteristic(CurrentTemperature)
+      .onGet(this.getCurrentTemperature.bind(this));
 
     // subscribe to device events
     device.powerChanges.subscribe((power) => {
@@ -137,5 +145,12 @@ export default class ElectricMat {
     this.log.debug('Set Temperature:', temperature);
 
     await this.service.setTemperature(this.device, temperature);
+  }
+
+  async getCurrentTemperature(): Promise<CharacteristicValue> {
+    // this device does not support to get current temperature
+    // so, throw an error to indicate that the operation is not supported
+    const { HAPStatus, HapStatusError } = this.platform.api.hap;
+    throw new HapStatusError(HAPStatus.SERVICE_COMMUNICATION_FAILURE);
   }
 }

--- a/src/homebridge/electric-mat.device.ts
+++ b/src/homebridge/electric-mat.device.ts
@@ -149,7 +149,15 @@ export default class ElectricMat {
 
   async getCurrentTemperature(): Promise<CharacteristicValue> {
     // this device does not support to get current temperature
-    // so, throw an error to indicate that the operation is not supported
+
+    // if the user wants to show the current temperature as the target temperature,
+    // we can return the current temperature as the target temperature
+    if (this.platform.config.showCurrentTemperatureAsTarget) {
+      return this.getTemperature();
+    }
+
+    // if the user does not want to show the current temperature as the target temperature,
+    // we should throw an error to indicate that the current temperature is not supported
     const { HAPStatus, HapStatusError } = this.platform.api.hap;
     throw new HapStatusError(HAPStatus.NOT_ALLOWED_IN_CURRENT_STATE);
   }

--- a/src/navien/navien.service.ts
+++ b/src/navien/navien.service.ts
@@ -1,7 +1,7 @@
 import { Logger } from 'homebridge';
 
 import { AwsPubSub } from '../aws/pubsub';
-import { NavienHomebridgePlatform, NavienPlatformConfig } from '../platform';
+import { NavienHomebridgePlatform } from '../platform';
 import { ApiException } from './exceptions';
 import { Device } from './interfaces';
 import { NavienApi } from './navien.api';
@@ -18,10 +18,9 @@ export class NavienService {
   constructor(
     private readonly platform: NavienHomebridgePlatform,
     private readonly log: Logger,
-    private readonly config: NavienPlatformConfig,
   ) {
     this.auth = new NavienAuth(log);
-    this.sessionManager = new NavienSessionManager(log, this.auth, platform.createPersist(), config);
+    this.sessionManager = new NavienSessionManager(log, this.auth, platform.createPersist(), platform.config);
     this.api = new NavienApi(log, this.sessionManager);
   }
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -16,6 +16,7 @@ export type NavienPlatformConfig = PlatformConfig & {
   password?: string;
   refreshToken?: string;
   accountSeq?: number;
+  showCurrentTemperatureAsTarget: boolean;
 };
 
 /**
@@ -30,16 +31,18 @@ export class NavienHomebridgePlatform implements DynamicPlatformPlugin {
   // this is used to track restored cached accessories
   public readonly accessories: NavienPlatformAccessory[] = [];
 
+  public readonly config: NavienPlatformConfig;
   public readonly navienService: NavienService;
 
   constructor(
     public readonly log: Logger,
-    public readonly config: PlatformConfig,
+    config: PlatformConfig,
     public readonly api: API,
   ) {
     this.log.debug('Finished initializing platform:', config.platform);
 
-    this.navienService = new NavienService(this, log, config as NavienPlatformConfig);
+    this.config = config as NavienPlatformConfig;
+    this.navienService = new NavienService(this, log);
 
     this.api.on('didFinishLaunching', this.onLaunched);
   }


### PR DESCRIPTION
This pull request fixes an error related to getting the current temperature and adds a new configuration option called showCurrentTemperatureAsTarget. The error was thrown when trying to get the current temperature, and now it is handled properly. The showCurrentTemperatureAsTarget option allows the user to choose whether to display the current temperature as the target temperature on the Apple Home screen. When set to true, the target temperature will be displayed, but it may not accurately reflect the home's climate. When set to false, a "No response" warning will be shown instead.