### PR TITLE
feat: implement heater service and add accessoryType property to config

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -12,17 +12,14 @@
         "oneOf": [
           {
             "title": "Navien Smart Account",
-            "enum": [
-              "account"
-            ]
+            "enum": [ "account" ]
           },
           {
             "title": "Token",
-            "enum": [
-              "token"
-            ]
+            "enum": [ "token" ]
           }
-        ]
+        ],
+        "required": true
       },
       "username": {
         "title": "Username",
@@ -54,6 +51,22 @@
         "type": "boolean",
         "default": true,
         "description": "When set to `true`, displays the accessory's target temperature on the Apple Home screen, but may inaccurately reflect the home's climate as the target temperature. When `false`, shows \"--°\" with a \"No response\" warning on the Apple Home screen, but does not set the home's climate to the target temperature."
+      },
+      "accessoryType": {
+        "title": "Accessory Type",
+        "type": "string",
+        "default": "HeaterCooler",
+        "oneOf": [
+          {
+            "title": "Heater",
+            "enum": [ "HeaterCooler" ]
+          },
+          {
+            "title": "Thermostat",
+            "enum": [ "Thermostat" ]
+          }
+        ],
+        "required": true
       }
     }
   }

--- a/src/navien/navien.device.ts
+++ b/src/navien/navien.device.ts
@@ -63,6 +63,12 @@ export class NavienDevice {
     this.powerSubject.next(value);
   }
 
+  get isIdle() {
+    const { heatControl } = this.json.Properties.registry.attributes.functions;
+    const idleTemperature = heatControl.rangeMin - parseFloat(heatControl.unit);
+    return this._power && this._temperature === idleTemperature;
+  }
+
   get temperature() {
     return this._temperature;
   }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -17,6 +17,7 @@ export type NavienPlatformConfig = PlatformConfig & {
   refreshToken?: string;
   accountSeq?: number;
   showCurrentTemperatureAsTarget: boolean;
+  accessoryType: 'HeaterCooler' | 'Thermostat';
 };
 
 /**


### PR DESCRIPTION
fixes: #9

This pull request adds a new heater service and includes the addition of the accessoryType property to the NavienPlatformConfig interface. The heater service allows for controlling the temperature of the heater, and the accessoryType property specifies whether the accessory is a heater or a thermostat.