### PR TITLE
fix: handle missing fields from device event

### DIFF
--- a/src/aws/interfaces/device-event.inteface.ts
+++ b/src/aws/interfaces/device-event.inteface.ts
@@ -36,11 +36,11 @@ export interface NavienDesiredState {
 export interface NavienReportedState {
     info: DeviceInfo;
     connected: boolean;
-    errorCode: number;
-    operationMode: OperationMode;
-    heater: HeaterState;
-    childLock: boolean;
-    schedule: ScheduleState;
+    errorCode?: number;
+    operationMode?: OperationMode;
+    heater?: HeaterState;
+    childLock?: boolean;
+    schedule?: ScheduleState;
 }
 
 export enum OperationMode {
@@ -51,16 +51,16 @@ export enum OperationMode {
 export type HeaterState = SingleHeaterState | DoubleHeaterState;
 
 export interface SingleHeaterState {
-    single: HeaterItemState;
+    single?: HeaterItemState;
 }
 
 export interface DoubleHeaterState {
-    left: HeaterItemState;
-    right: HeaterItemState;
+    left?: HeaterItemState;
+    right?: HeaterItemState;
 }
 
 export interface HeaterItemState {
-    enable: boolean;
+    enable?: boolean;
     temperature: {
         set: number; // celcius
     };

--- a/src/navien/navien.device-status.ts
+++ b/src/navien/navien.device-status.ts
@@ -1,7 +1,7 @@
 import { Logger } from 'homebridge';
 import { BehaviorSubject, Subscription } from 'rxjs';
 
-import { OperationMode } from '../aws/interfaces/index.js';
+import { DoubleHeaterState, OperationMode, SingleHeaterState } from '../aws/interfaces/index.js';
 import { AwsPubSub } from '../aws/pubsub.js';
 import { NavienDevice } from './navien.device.js';
 
@@ -36,21 +36,35 @@ export class NavienDeviceStatusRepository {
       }
 
       // status update
-      const isActive = state.operationMode === OperationMode.ON;
-      const temperature = ('left' in state.heater ?
-        state.heater.left : // TODO: handle left and right
-        state.heater.single
-      ).temperature.set;
-      const doubleTemperature = 'left' in state.heater ?
-        { left: state.heater.left.temperature.set, right: state.heater.right.temperature.set } :
-        temperature;
-      const isLocked = state.childLock;
-      this.log.info('[AWS PubSub] current status:', { name: this.device.name, isActive, temperature: doubleTemperature, isLocked });
+      if ('heater' in state) {
+        const heater = state.heater!;
+        if ('left' in heater || 'right' in heater) {
+          this._isDouble = true;
+        }
+        if ('single' in heater) {
+          this._isDouble = false;
+        }
+        const temperature = (this._isDouble ?
+          // TODO: handle left and right
+          (heater as DoubleHeaterState)?.left:
+          (heater as SingleHeaterState)?.single
+        )?.temperature?.set;
+        if (temperature !== undefined) {
+          this.temperature = temperature;
+        }
+      }
+      if ('childLock' in state) {
+        this.isLocked = state.childLock!;
+      }
+      if ('operationMode' in state) {
+        this.isActive = (state.operationMode === OperationMode.ON);
+      }
 
-      this.isActive = isActive;
-      this.temperature = temperature;
-      this.isLocked = isLocked;
-      this._isDouble = 'left' in state.heater;
+      // updated status
+      this.log.info(
+        '[AWS PubSub] current status:',
+        { name: this.device.name, isActive: this.isActive, temperature: this.temperature, isLocked: this.isLocked },
+      );
     });
   }
 


### PR DESCRIPTION
# 환경
- EMW720(온수매트)
- 퀸사이즈(분리난방)

# 배경
최근에 업데이트되면서 변경된 것인지, aws 로부터 내려오는 device event 의 필드 중 일부가 누락되어 오는 경우가 있어서 아래와 같은 문제가 발생하며 지속적으로 homebridge 가 죽는 경우가 있었습니다.
<img width="1323" alt="image" src="https://github.com/user-attachments/assets/19c081cf-ab46-4a13-914e-c3526a032dfa" />
<img width="1324" alt="image" src="https://github.com/user-attachments/assets/ed033526-37b4-49bf-bbaf-5ded2aa9a043" />

제 환경에서 state(`event.payload.state.reported`)를 찍어보면 아래와 같은 이벤트들이 찍히는 것을 확인했습니다.
```json
{"connected":true,"info":{"deviceId":"***","modelCode":17},"heater":{"left":{"temperature":{"current":25.5,"set":31}}}}
{"connected":true,"info":{"deviceId":"***","modelCode":17},"heater":{"output":true}}
{"connected":true,"info":{"deviceId":"***","modelCode":17},"waterLevel":3}
```
위와 같이 `state.operationMode`, `state.heater`, `state.heater.left` 등의 필드들이 없는 경우가 있었고, 해당 이벤트들이 문제가 되는 상황이었습니다. 추측이지만 기존에는 현재의 모든 state 를 내려줬다면, 이제는 일부 변화가 있는 state 만 내려주는 것 같습니다(e.g. 전원을 끈 경우 `state.operationMode` 만 포함).

# 수정사항
* `device-event.interface.ts`: event 스키마를 수정하여 제 환경에서 누락되는 경우가 있는 필드들을 nullable 로 수정하였습니다.
* `navien.device-status.ts`: 필드의 존재 여부에 따라, 필드가 존재하는 경우에만 업데이트하도록 수정하였습니다.

위의 수정사항으로 기존의 동작과의 차이가 발생하지는 않을 것이라 예상합니다.