### PR TITLE
fix: disable beep for status update

### DIFF
--- a/src/navien/navien.api.ts
+++ b/src/navien/navien.api.ts
@@ -144,7 +144,7 @@ export class NavienApi {
               event: {
                 modelCode: parseInt(modelCode),
               },
-              beep: this.soundEnabled,
+              beep: payload !== undefined && this.soundEnabled,
               ...payload,
             },
           },


### PR DESCRIPTION
안녕하세요, 겨울이 돌아와서 온수매트를 다시 사용하려 하는데 수정이 필요한 부분이 하나 있어 PR 드립니다.
시간 되실 때 리뷰 부탁드립니다 🙏 

코드를 리팩토링하시면서 바뀐 것인지는 잘 모르겠지만, device control api 쪽에 요청을 보낼 때 `controlDevice` 를 호출하는 것으로 보입니다.
그런데 이 controlDevice 는 실제로 세팅(설정 온도 등)을 바꾸는 경우 외에도 `requestRefreshingStatus` -> `_initializeDevice` -> `initializeDevice` -> `controlDevice` 의 경로로 호출될 수 있습니다.
이때 `payload.state.desired.beep: true` 로 설정되면, 실제 세팅이 변경되지 않았음에도 hb 에서 status refresh 를 할 때마다 소리가 나게 됩니다.
그래서 해당 경로에서는 `beep: false` 로 설정되도록 코드를 수정해보았습니다. 일단은 `controlDevice` 로 들어오는 payload 가 없으면 `beep: false` 로 설정되도록 해보았는데, 더 좋은 아이디어가 있으시면 알려주세요!